### PR TITLE
Fix: Change double quote to single quote

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml up 
 3. Crear usuario root
 ```bash
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml exec server \
-  sh -lc "cd /app && bun run cli -- user create-root root_cli StrongRootP4ss!1"
+  sh -lc 'cd /app && bun run cli -- user create-root root_cli StrongRootP4ss!1'
 ```
 
 ## API


### PR DESCRIPTION
To prevent a bash scape, we need to use single quote in the docker compose root user create